### PR TITLE
Scale Canvas to "fullscreen" with aspect ratio

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,6 +1,11 @@
 html, body {
+    width: 100%;
     height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
 }
+
 body {
   margin: 0;
 }
@@ -13,7 +18,10 @@ body {
 }
 
 main {
-  padding: 0.5rem;
+    transform-origin: 0 0;
+    -webkit-transform-origin: 0 0;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 h1 {
@@ -26,9 +34,11 @@ p {
 
 #install {
   font-size: 1rem;
+    position: absolute;
+    bottom: 0;
 }
 
-#install.hidden {
+#install.hidden, div.info.hidden {
   display: none;
 }
 
@@ -36,3 +46,9 @@ canvas {
   display: block;
 }
 
+div.info {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: rgba(255,255,255,0.8);
+}

--- a/css/app.css
+++ b/css/app.css
@@ -7,10 +7,6 @@ html, body {
 }
 
 body {
-  margin: 0;
-}
-
-body {
     font-family: Helvetica, Arial, sans;
     background: linear-gradient(0deg, #aaa, #ccc 30%, #fff);
     background-size: 100% 100%;
@@ -33,17 +29,17 @@ p {
 }
 
 #install {
-  font-size: 1rem;
+    font-size: 1rem;
     position: absolute;
     bottom: 0;
 }
 
 #install.hidden, div.info.hidden {
-  display: none;
+    display: none;
 }
 
 canvas {
-  display: block;
+    display: block;
 }
 
 div.info {

--- a/index.html
+++ b/index.html
@@ -12,10 +12,12 @@
     <link rel="stylesheet" href="css/app.css">
   </head>
   <body>
-    <main>
-      <h1>Canvas game template <button id="install" class="hidden">Install</button></h1>
-      <p>This a simple game template using Canvas for drawing and keyboard interaction with the arrows.</p>
-    </main>
+    <main></main>
+    <div class="info">
+        <h1>Canvas game template</h1>
+        <p>This a simple game template using Canvas for drawing and keyboard interaction with the arrows.</p>
+    </div>
+    <button id="install" class="hidden">Install</button>
 
     <script type="text/javascript" src="js/input.js"></script>
     <script type="text/javascript" src="js/lib/install.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -53,11 +53,15 @@ window.onload = function() {
     // Create the canvas
     var mainContainer = document.querySelector('main');
     var canvas = document.createElement("canvas");
+    var infoContainer = document.querySelector('div.info');
     var ctx = canvas.getContext("2d");
-    canvas.width = 320;
-    canvas.height = 240;
+    var initialCanvasWidth = canvas.width = 320;
+    var initialCanvasHeight = canvas.height = 480;
     mainContainer.appendChild(canvas);
 
+    infoContainer.addEventListener('click', function(ev) {
+        infoContainer.classList.add('hidden');
+    });
     // The player's state
     var player = {
         x: 0,
@@ -75,6 +79,10 @@ window.onload = function() {
         pause();
     });
 
+    window.addEventListener('resize', resize);
+
+    //Initially resize the game canvas.
+    resize();
     // Let's play this game!
     reset();
     var then = Date.now();
@@ -158,5 +166,31 @@ window.onload = function() {
         requestAnimFrame(main);
     }
 
+    // based on: https://hacks.mozilla.org/2013/05/optimizing-your-javascript-game-for-firefox-os/
+    function resize() {
+        var browser = [
+            window.innerWidth,
+            window.innerHeight
+        ];
+        // Minimum scale
+        var scale = Math.min(
+                browser[0] / initialCanvasWidth,
+                browser[1] / initialCanvasHeight);
+        // Scaled content size
+        var size = [
+                initialCanvasWidth * scale,
+                initialCanvasHeight * scale
+        ];
+        // Offset from top/left
+        var offset = [
+                (browser[0] - size[0]) / 2,
+                (browser[1] - size[1]) / 2
+        ];
+
+        // Apply CSS transform
+        var rule = "translate(" + offset[0] + "px, " + offset[1] + "px) scale(" + scale + ")";
+        mainContainer.style.transform = rule;
+        mainContainer.style.webkitTransform = rule;
+    }
 
 };

--- a/js/app.js
+++ b/js/app.js
@@ -174,17 +174,17 @@ window.onload = function() {
         ];
         // Minimum scale
         var scale = Math.min(
-                browser[0] / initialCanvasWidth,
-                browser[1] / initialCanvasHeight);
+            browser[0] / initialCanvasWidth,
+            browser[1] / initialCanvasHeight);
         // Scaled content size
         var size = [
-                initialCanvasWidth * scale,
-                initialCanvasHeight * scale
+            initialCanvasWidth * scale,
+            initialCanvasHeight * scale
         ];
         // Offset from top/left
         var offset = [
-                (browser[0] - size[0]) / 2,
-                (browser[1] - size[1]) / 2
+            (browser[0] - size[0]) / 2,
+            (browser[1] - size[1]) / 2
         ];
 
         // Apply CSS transform


### PR DESCRIPTION
Hi,

I've added a resize function and event listener to scale the canvas with correct aspect ration. I've set the canvas size to 320x480 (Portrait mode) initially. Maybe it's a small step towards [Issue #8](https://github.com/mozilla/mortar-game-stub/issues/8) 

There are some more changes:
- Hint is now been shown as a overlay which could be hidden by click.
- Install button is positioned at the bottom and floats over the game canvas. 

The code is based on: https://hacks.mozilla.org/2013/05/optimizing-your-javascript-game-for-firefox-os/
